### PR TITLE
Support `on_*_entry`, `on_*_exit` and implicit callback methods being `private`.

### DIFF
--- a/lib/workflow.rb
+++ b/lib/workflow.rb
@@ -250,7 +250,7 @@ module Workflow
     end
 
     def run_action_callback(action_name, *args)
-      self.send action_name.to_sym, *args if self.respond_to?(action_name.to_sym)
+      self.send action_name.to_sym, *args if self.respond_to?(action_name.to_sym, true)
     end
 
     def run_on_entry(state, prior_state, triggering_event, *args)
@@ -258,7 +258,7 @@ module Workflow
         instance_exec(prior_state.name, triggering_event, *args, &state.on_entry)
       else
         hook_name = "on_#{state}_entry"
-        self.send hook_name, prior_state, triggering_event, *args if self.respond_to? hook_name
+        self.send hook_name, prior_state, triggering_event, *args if self.respond_to?(hook_name, true)
       end
     end
 
@@ -268,7 +268,7 @@ module Workflow
           instance_exec(new_state.name, triggering_event, *args, &state.on_exit)
         else
           hook_name = "on_#{state}_exit"
-          self.send hook_name, new_state, triggering_event, *args if self.respond_to? hook_name
+          self.send hook_name, new_state, triggering_event, *args if self.respond_to?(hook_name, true)
         end
       end
     end


### PR DESCRIPTION
Passing `true` as the second argument to `respond_to?` searches methods that have been marked `private` as well. This patch adds that so callback methods can be private.
