### PR TITLE
Add a `Gemfile` for bundler support, add development dependencies to the gemspec.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ doc/
 html/
 *.swp
 .yardoc
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source :rubygems
+
+gemspec

--- a/workflow.gemspec
+++ b/workflow.gemspec
@@ -55,5 +55,10 @@ Gem::Specification.new do |s|
     end
   else
   end
+
+  s.add_development_dependency "rake"
+  s.add_development_dependency "mocha"
+  s.add_development_dependency "activerecord"
+  s.add_development_dependency "sqlite3"
 end
 


### PR DESCRIPTION
Having a `Gemfile` lets one quickly get the dependencies they need to develop your library. I've added a simple one that uses the gemspec.

I also added things needed to run the tests to the gemspec as development dependencies.
