### PR TITLE
Define an on_error hook

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -330,6 +330,26 @@ example][advanced_hooks_and_validation_test].
 
 [advanced_hooks_and_validation_test]: http://github.com/geekq/workflow/blob/master/test/advanced_hooks_and_validation_test.rb
 
+### on_error
+
+If you want to do custom exception handling internal to workflow, you can define an `on_error` hook in your workflow.  
+For example:
+
+    workflow do
+      state :first do
+        event :forward, :transitions_to => :second
+      end
+      state :second
+
+      on_error do |error, from, to, event, *args|
+        Log.info "Exception(#error.class) on #{from} -> #{to}" 
+      end
+    end
+
+If forward! results in an exception, `on_error` is invoked and the workflow stays in a 'first' state.  This capability 
+is particularly useful if your errors are transient and you want to queue up a job to retry in the future without 
+affecting the existing workflow state.
+
 ### Guards
 
 If you want to halt the transition conditionally, you can just raise an

--- a/lib/workflow.rb
+++ b/lib/workflow.rb
@@ -6,7 +6,7 @@ module Workflow
   class Specification
 
     attr_accessor :states, :initial_state, :meta,
-      :on_transition_proc, :before_transition_proc, :after_transition_proc
+      :on_transition_proc, :before_transition_proc, :after_transition_proc, :on_error_proc
 
     def initialize(meta = {}, &specification)
       @states = Hash.new
@@ -56,6 +56,10 @@ module Workflow
 
     def on_transition(&proc)
       @on_transition_proc = proc
+    end
+
+    def on_error(&proc)
+      @on_error_proc = proc
     end
   end
 
@@ -177,7 +181,12 @@ module Workflow
       run_before_transition(from, to, name, *args)
       return false if @halted
 
-      return_value = run_action(event.action, *args) || run_action_callback(event.name, *args)
+      begin
+        return_value = run_action(event.action, *args) || run_action_callback(event.name, *args)
+      rescue Exception => e
+        run_on_error(e, from, to, name, *args)
+      end
+
       return false if @halted
 
       run_on_transition(from, to, name, *args)
@@ -234,6 +243,15 @@ module Workflow
     def run_before_transition(from, to, event, *args)
       instance_exec(from.name, to.name, event, *args, &spec.before_transition_proc) if
         spec.before_transition_proc
+    end
+
+    def run_on_error(error, from, to, event, *args)
+      if spec.on_error_proc
+        instance_exec(error, from.name, to.name, event, *args, &spec.on_error_proc)
+        halt(error.message)
+      else
+        raise error
+      end
     end
 
     def run_on_transition(from, to, event, *args)

--- a/test/on_error_test.rb
+++ b/test/on_error_test.rb
@@ -1,0 +1,52 @@
+require File.join(File.dirname(__FILE__), 'test_helper')
+require 'workflow'
+
+class OnErrorTest < Test::Unit::TestCase
+  # A class that does not handle errors in an error block
+  class NoErrorBlock
+    include Workflow
+    workflow do
+      state :first do
+        event :forward, :transitions_to => :second do
+          raise "This is some random runtime error"
+        end
+      end
+      state :second
+    end
+  end
+
+  # A class that handles errors in an error block
+  class ErrorBlock
+    attr_reader :errors
+
+    def initialize
+      @errors = {}
+    end
+
+    include Workflow
+    workflow do
+      state :first do
+        event :forward, :transitions_to => :second do
+          raise "This is some random runtime error"
+        end
+      end
+      state :second
+      on_error { |error, from, to, event, *args| @errors.merge!({:error => error.class, :from => from, :to => to, :event => event, :args => args}) }
+    end
+  end
+
+
+  test 'that an exception is raised if there is no associated on_error block' do
+    flow = NoErrorBlock.new
+    assert_raise( RuntimeError, "This is some random runtime error" ) { flow.forward! }
+    assert_equal(true, flow.first?)
+  end
+  
+  test 'that on_error block is called when an exception is raised and the transition is halted' do
+    flow = ErrorBlock.new
+    assert_nothing_raised { flow.forward! }
+    assert_equal({:error => RuntimeError, :from=>:first, :to=>:second, :event=>:forward, :args=>[]}, flow.errors)
+    # transition should not happen
+    assert_equal(true, flow.first?)
+  end
+end


### PR DESCRIPTION
on_error hook is invoked when any exception occurs in the main action block

We found this useful when implementing automatic error recovery.

Cheers,
jyanowitz@groupon.com
naren@groupon.com
