### PR TITLE
Update Gem in respect to new rails deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "http://www.rubygems.org"
+
+gemspec

--- a/lib/workflow.rb
+++ b/lib/workflow.rb
@@ -315,7 +315,7 @@ module Workflow
     # On transition the new workflow state is immediately saved in the
     # database.
     def persist_workflow_state(new_value)
-      update_attribute self.class.workflow_column, new_value
+      update_attributes self.class.workflow_column => new_value
     end
 
     private

--- a/workflow.gemspec
+++ b/workflow.gemspec
@@ -55,5 +55,9 @@ Gem::Specification.new do |s|
     end
   else
   end
-end
 
+  s.add_dependency("rake")
+  s.add_development_dependency("activerecord")
+  s.add_development_dependency("sqlite3")
+  s.add_development_dependency("mocha")
+end


### PR DESCRIPTION
In newest versions of Rails appears new warning message

```
DEPRECATION WARNING: update_attribute is deprecated and will be removed in Rails 4. If you want to skip mass-assignment protection, callbacks, and modifying updated_at, use update_column. If you do want those things, use update_attributes.
```

Link to this issue https://github.com/rails/rails/pull/6739

I also have add Gemfile and add some dependencies to gemspec. I have found what tests are not running without `doc` and `tmp` folders and it's a little bit weird. 
