### PR TITLE
Fixed update_attributeS issue

### DIFF
--- a/lib/workflow.rb
+++ b/lib/workflow.rb
@@ -338,7 +338,7 @@ module Workflow
     # On transition the new workflow state is immediately saved in the
     # database.
     def persist_workflow_state(new_value)
-      update_attributes self.class.workflow_column => new_value
+      update_column self.class.workflow_column, new_value
     end
 
     private


### PR DESCRIPTION
Hi,

as reported in <a href="https://github.com/geekq/workflow/issues/57">Issue #57</a>, adding `update_attributes` instead of  `update_attribute` causes problems related with mass assignment.
You can either add workflow_state to attr_accessible (which is inacceptable for me), use update_attributes with `without_protection` attribute (which skips mass assignment protection), or use update_column method (which skips validations, callbacks etc) – I don’t have enough time to dig in workflows code, to decide which one fits here better, so please review this before merging.
