### PR TITLE
Add Ruby 2.0.0 to Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ before_install:
 
 rvm:
   - 1.9.3
+  - 2.0.0
 
 matrix:
   include:


### PR DESCRIPTION
Now that Ruby 2.0.0 is out, it's time to officially support it! (I tested and the specs pass.)

It would also be great to have a new release. I learned the hard way (through hours of debugging) that workflow 0.8.7 doesn't include the private/protected callback method fixes, and hence doesn't work in Ruby 2.0.0.
