### PR TITLE
Remove require of workflow/draw to prevent warnings on production systems.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -465,7 +465,15 @@ Documenting with diagrams
 -------------------------
 
 You can generate a graphical representation of your workflow for
-documentation purposes. S. Workflow::create_workflow_diagram.
+documentation purposes e.g. as a rake task:
+
+    namespace :doc do
+      desc "Generate a workflow graph for a model passed e.g. as 'MODEL=Order'."
+      task :workflow => :environment do
+        require 'workflow/draw'
+        Workflow::Draw::workflow_diagram(ENV['MODEL'].constantize)
+      end
+    end
 
 
 Earlier versions

--- a/lib/workflow.rb
+++ b/lib/workflow.rb
@@ -3,7 +3,6 @@ require 'rubygems'
 require 'workflow/specification'
 require 'workflow/adapters/active_record'
 require 'workflow/adapters/remodel'
-require 'workflow/draw'
 
 # See also README.markdown for documentation
 module Workflow

--- a/lib/workflow/draw.rb
+++ b/lib/workflow/draw.rb
@@ -18,9 +18,10 @@ module Workflow
     # You can use this method in your own Rakefile like this:
     #
     #     namespace :doc do
-    #       desc "Generate a graph of the workflow."
-    #       task :workflow
-    #         Workflow::workflow_diagram(Order)
+    #       desc "Generate a workflow graph for a model passed e.g. as 'MODEL=Order'."
+    #       task :workflow => :environment do
+    #         require 'workflow/draw'
+    #         Workflow::Draw::workflow_diagram(ENV['MODEL'].constantize)
     #       end
     #     end
     #

--- a/test/main_test.rb
+++ b/test/main_test.rb
@@ -438,6 +438,7 @@ class MainTest < ActiveRecordTestCase
   test 'diagram generation' do
     begin
       $stdout = StringIO.new('', 'w')
+      require 'workflow/draw'
       Workflow::Draw::workflow_diagram(Order, :path => '/tmp')
       assert_match(/run the following/, $stdout.string,
         'PDF should be generate and a hint be given to the user.')


### PR DESCRIPTION
As suggested by @plukevdh I have removed the `require "workflow/draw"` since the gems needed to generate dot graphs are causing trouble on production systems.

From the related issue #72:

> In `lib/workflow/draw.rb` the ruby-graphviz and activesupport gems are required on top
> which means on my production boxes every cronned rake task triggers a flood of emails 
> due to the `$stderr.puts "Could not load ...` message unless I include ruby-graphviz which 
> I don't really want on production boxes.

This commit removes the require, adapts the test and fixes the broken examples of how to use this feature in the README and documentation.
