### PR TITLE
Allow protected/private on_entry/on_exit callbacks

### DIFF
--- a/lib/workflow.rb
+++ b/lib/workflow.rb
@@ -187,7 +187,7 @@ module Workflow
         instance_exec(prior_state.name, triggering_event, *args, &state.on_entry)
       else
         hook_name = "on_#{state}_entry"
-        self.send hook_name, prior_state, triggering_event, *args if self.respond_to? hook_name
+        self.send hook_name, prior_state, triggering_event, *args if has_callback? hook_name
       end
     end
 
@@ -197,7 +197,7 @@ module Workflow
           instance_exec(new_state.name, triggering_event, *args, &state.on_exit)
         else
           hook_name = "on_#{state}_exit"
-          self.send hook_name, new_state, triggering_event, *args if self.respond_to? hook_name
+          self.send hook_name, new_state, triggering_event, *args if has_callback? hook_name
         end
       end
     end

--- a/test/main_test.rb
+++ b/test/main_test.rb
@@ -268,11 +268,6 @@ class MainTest < ActiveRecordTestCase
         end
         state :two
       end
-
-      private
-      def another_transition(args)
-        args.another_tran
-      end
     end
     a = c.new
     a.my_transition!(args)
@@ -281,6 +276,8 @@ class MainTest < ActiveRecordTestCase
   test '#53 Support for non public transition callbacks' do
     args = mock()
     args.expects(:log).with('in private callback').once
+    args.expects(:log).with('in protected on_exit callback').twice
+    args.expects(:log).with('in protected on_entry callback').once
     args.expects(:log).with('in protected callback in the base class').once
 
     b = Class.new # the base class with a protected callback
@@ -301,6 +298,16 @@ class MainTest < ActiveRecordTestCase
         end
         state :assigned
         state :assigned_old
+      end
+
+      protected
+
+      def on_new_exit new_state, event, args
+        args.log('in protected on_exit callback')
+      end
+
+      def on_assigned_entry prior_state, event, args
+        args.log('in protected on_entry callback')
       end
 
       private


### PR DESCRIPTION
#53 added support for protected/private transition callbacks, but not for `on_*_entry` and `on_*_exit` callbacks. This patch uses the same `has_callback?` handler for them.
