### PR TITLE
workaround for activerecord bug with automatic state scopes. 

### DIFF
--- a/lib/workflow/adapters/active_record.rb
+++ b/lib/workflow/adapters/active_record.rb
@@ -44,19 +44,19 @@ module Workflow
           class << object
             alias_method :workflow_without_scopes, :workflow unless method_defined?(:workflow_without_scopes)
             alias_method :workflow, :workflow_with_scopes
-          end 
+          end
         end
 
         def workflow_with_scopes(&specification)
           workflow_without_scopes(&specification)
           states     = workflow_spec.states.values
           eigenclass = class << self; self; end
-          
+
           states.each do |state|
             # Use eigenclass instead of `define_singleton_method`
             # to be compatible with Ruby 1.8+
             eigenclass.send(:define_method, "with_#{state}_state") do
-              where(workflow_column.to_sym => state)
+              where("#{table_name}.#{self.workflow_column.to_sym} = ?", state.to_s)
             end
           end
         end


### PR DESCRIPTION
I'm running a project with Rails 3.2.11 and ruby 1.9.3p448 and there's a bug in its version of ActiveRecord which causes Arel to blow up when you use the automatically generated workflow scopes.

For example:

```
[36] pry(main)> Loan.with_checked_out_state.all
TypeError: Cannot visit Workflow::State
from /Users/james/.rvm/gems/ruby-1.9.3-p448@checkout/gems/arel-3.0.2/lib/arel/visitors/visitor.rb:25:in `rescue in visit'
```

This patch solved the problem for me. It seems to behave slightly differently in that it doesn't return a relation, but I confirmed it is chainable with other Active Record query interface methods. It should be drop in compatible.

Confirmed that it works with rails 3.2.14.
