### PR TITLE
Adds the What-Would-Travis-Do gem to run the full set of tests locally.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
+language: ruby
 before_install:
   - sudo apt-get install -qq graphviz
+script: bundle exec rake test
 
 rvm:
   - 2.0.0

--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,15 @@
 require 'rubygems'
-require 'rake/testtask'
-require 'rdoc/task'
-
 require 'bundler'
 Bundler.setup
 
-task :default => [:test]
-
 require 'rake'
+require 'rake/testtask'
+require 'rdoc/task'
+require 'wwtd/tasks'
+
+desc 'Default: run all tests via Travis-CI simulation (wwtd:local).'
+task :default => 'wwtd:local'
+
 Rake::TestTask.new do |t|
   t.libs << 'test'
   t.verbose = true

--- a/gemfiles/Gemfile.rails-2.3.x
+++ b/gemfiles/Gemfile.rails-2.3.x
@@ -8,4 +8,5 @@ group :development do
   gem "mocha"
   gem "rake"
   gem "ruby-graphviz", "~> 1.0.0"
+  gem "wwtd", "~> 0.5.3"
 end

--- a/gemfiles/Gemfile.rails-3.x
+++ b/gemfiles/Gemfile.rails-3.x
@@ -8,4 +8,5 @@ group :development do
   gem "mocha"
   gem "rake"
   gem "ruby-graphviz", "~> 1.0.0"
+  gem "wwtd", "~> 0.5.3"
 end

--- a/gemfiles/Gemfile.rails-4.0
+++ b/gemfiles/Gemfile.rails-4.0
@@ -10,4 +10,5 @@ group :development do
   gem "mocha"
   gem "rake"
   gem "ruby-graphviz", "~> 1.0.0"
+  gem "wwtd", "~> 0.5.3"
 end

--- a/gemfiles/Gemfile.rails-edge
+++ b/gemfiles/Gemfile.rails-edge
@@ -10,4 +10,5 @@ group :development do
   gem "rake"
   gem "ruby-graphviz", "~> 1.0.0"
   gem 'protected_attributes'
+  gem "wwtd", "~> 0.5.3"
 end

--- a/workflow.gemspec
+++ b/workflow.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'mocha'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'ruby-graphviz', ['~> 1.0.0']
+  gem.add_development_dependency 'wwtd', '~> 0.5.3'
 end
 


### PR DESCRIPTION
[wwtd](https://rubygems.org/gems/wwtd) uses the `.travis.yml` file to run the set of tests locally.

I haven't been able to run `rake test` without a bunch of `MiniTest::Unit::TestCase is now Minitest::Test` errors; this should be a convenient way to work around that problem without needing to run `BUNDLE_GEMFILE=gemfiles/Gemfile.rails-edge bundle exec rake test` or similar.
