### PR TITLE
Add support for specifying event `if` conditions with a method name symbol

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -421,20 +421,26 @@ representation of the workflow. See below.
 Conditional event transitions
 -----------------------------
 
-Conditions are procs or lambdas added to events, like so:
+Conditions can be a "method name symbol" with a corresponding instance method, a `proc` or `lambda` which are added to events, like so:
 
     state :off
       event :turn_on, :transition_to => :on,
-                      :if => proc { |device| device.battery_level > 0 }
+                      :if => :sufficient_battery_level?
+
       event :turn_on, :transition_to => :low_battery,
-                      :if => proc { |device| device.battery_level > 10 }
+                      :if => proc { |device| device.battery_level > 0 }
+    end
+
+    # corresponding instance method
+    def sufficient_battery_level?
+      battery_level > 10
     end
 
 When calling a `device.can_<fire_event>?` check, or attempting a `device.<event>!`, each event is checked in turn:
 
-* With no :if check, proceed as usual.
-* If an :if check is present, proceed if it evaluates to true, or drop to the next event.
-* If you've run out of events to check (eg. battery_level == 0), then the transition isn't possible.
+* With no `:if` check, proceed as usual.
+* If an `:if` check is present, proceed if it evaluates to true, or drop to the next event.
+* If you've run out of events to check (eg. `battery_level == 0`), then the transition isn't possible.
 
 
 Advanced transition hooks

--- a/lib/workflow/event.rb
+++ b/lib/workflow/event.rb
@@ -8,15 +8,23 @@ module Workflow
       @transitions_to = transitions_to.to_sym
       @meta = meta
       @action = action
-      @condition = if condition.nil? || condition.respond_to?(:call)
+      @condition = if condition.nil? || condition.is_a?(Symbol) || condition.respond_to?(:call)
                      condition
                    else
-                     raise TypeError, 'condition must be nil or callable (eg. a proc or lambda)'
+                     raise TypeError, 'condition must be nil, an instance method name symbol or a callable (eg. a proc or lambda)'
                    end
     end
 
     def condition_applicable?(object)
-      condition ? condition.call(object) : true
+      if condition
+        if condition.is_a?(Symbol)
+          object.send(condition)
+        else
+          condition.call(object)
+        end
+      else
+        true
+      end
     end
 
     def draw(graph, from_state)

--- a/lib/workflow/version.rb
+++ b/lib/workflow/version.rb
@@ -1,3 +1,3 @@
 module Workflow
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end

--- a/test/main_test.rb
+++ b/test/main_test.rb
@@ -530,7 +530,7 @@ class MainTest < ActiveRecordTestCase
       include Workflow
       workflow do
         state :off do
-          event :turn_on, :transitions_to => :on, :if => proc { |obj| obj.battery > 10 }
+          event :turn_on, :transitions_to => :on, :if => :sufficient_battery_level?
           event :turn_on, :transitions_to => :low_battery, :if => proc { |obj| obj.battery > 0 }
         end
         state :on
@@ -539,6 +539,10 @@ class MainTest < ActiveRecordTestCase
       attr_reader :battery
       def initialize(battery)
         @battery = battery
+      end
+
+      def sufficient_battery_level?
+        @battery > 10
       end
     end
 


### PR DESCRIPTION
Add the ability to define `if` conditions for `events` using an instance method name symbol, in addition to the already supported `proc` or `lambda` way.

``` ruby
state :off
  event :turn_on, :transition_to => :on,
                  :if => :sufficient_battery_level?

  event :turn_on, :transition_to => :low_battery,
                  :if => proc { |device| device.battery_level > 0 }
end

# corresponding instance method
def sufficient_battery_level?
  battery_level > 10
end
```

Here, the `:sufficient_battery_level?` method is invoked when evaluating the condition.
