### PR TITLE
Make all errors inherit from Workflow::Error

### DIFF
--- a/lib/workflow/errors.rb
+++ b/lib/workflow/errors.rb
@@ -1,5 +1,7 @@
 module Workflow
-  class TransitionHalted < StandardError
+  class Error < StandardError; end
+
+  class TransitionHalted < Error
 
     attr_reader :halted_because
 
@@ -10,9 +12,9 @@ module Workflow
 
   end
 
-  class NoTransitionAllowed < StandardError; end
+  class NoTransitionAllowed < Error; end
 
-  class WorkflowError < StandardError; end
+  class WorkflowError < Error; end
 
-  class WorkflowDefinitionError < StandardError; end
+  class WorkflowDefinitionError < Error; end
 end


### PR DESCRIPTION
This creates a new `Workflow::Error` class with all other errors inheriting from it. This way one can `rescue Workflow::Error` and just get workflow related errors.