### PR TITLE
Added a default scope of `without_<state_name>_state`

### DIFF
--- a/lib/workflow/adapters/active_record.rb
+++ b/lib/workflow/adapters/active_record.rb
@@ -37,8 +37,10 @@ module Workflow
       # Examples:
       #
       # Article.with_pending_state # => ActiveRecord::Relation
-      #
-      # Example above just adds `where(:state_column_name => 'pending')` to AR query and returns
+      # Payment.without_refunded_state # => ActiveRecord::Relation
+      #`
+      # Example above just adds `where(:state_column_name => 'pending')` or
+      # `where.not(:state_column_name => 'pending')` to AR query and returns
       # ActiveRecord::Relation.
       module Scopes
         def self.extended(object)
@@ -56,8 +58,13 @@ module Workflow
             define_singleton_method("with_#{state}_state") do
               where("#{table_name}.#{self.workflow_column.to_sym} = ?", state.to_s)
             end
+
+            define_singleton_method("without_#{state}_state") do
+              where.not("#{table_name}.#{self.workflow_column.to_sym} = ?", state.to_s)
+            end
           end
         end
+
       end
     end
   end

--- a/test/active_record_scopes_test.rb
+++ b/test/active_record_scopes_test.rb
@@ -45,5 +45,14 @@ class ActiveRecordScopesTest < ActiveRecordTestCase
   test 'have "with_accepted_state" scope' do
     assert_respond_to Article, :with_accepted_state
   end
+
+  test 'have "without_new_state" scope' do
+    assert_respond_to Article, :without_new_state
+  end
+
+  test 'have "without_accepted_state" scope' do
+    assert_respond_to Article, :without_accepted_state
+  end
+
 end
 


### PR DESCRIPTION
Sometimes it's nice to just fetch everything that's not in a certain state. This will allow me to clear quite a few self-defined scopes in my projects.