### PR TITLE
Properly check whether @workflow_state_column_name is defined.

### DIFF
--- a/lib/workflow.rb
+++ b/lib/workflow.rb
@@ -13,7 +13,7 @@ module Workflow
       if column_name
         @workflow_state_column_name = column_name.to_sym
       end
-      if !@workflow_state_column_name && superclass.respond_to?(:workflow_column)
+      if !instance_variable_defined?('@workflow_state_column_name') && superclass.respond_to?(:workflow_column)
         @workflow_state_column_name = superclass.workflow_column
       end
       @workflow_state_column_name ||= :workflow_state


### PR DESCRIPTION
The line `if @workflow_state_column_name ...` triggers "warning: instance variable @workflow_state_column_name not initialized" because it's not defined at that point unless a column name is explicitly passed. (Please note that `@foo ||= 'bar'` won't cause any warnings even if @foo is not defined yet.)