### PR TITLE
Custom handling when an unavailable transition is called

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -499,6 +499,30 @@ If forward! results in an exception, `on_error` is invoked and the workflow stay
 is particularly useful if your errors are transient and you want to queue up a job to retry in the future without
 affecting the existing workflow state.
 
+Note: this is not triggered by Workflow::NoTransitionAllowed exceptions.
+
+### on_unavailable_transition
+
+If you want to do custom handling when an unavailable transition is called, you can define an 'on_unavailable_transition' hook
+in your workflow. For example
+
+    workflow do
+      state :first
+      state :second do
+        event :backward, :transitions_to => :first
+      end
+
+      on_unavailable_transition do |from, to_name, *args|
+        Log.warn "Workflow: #{from} does not have #{to_name} available to it"
+      end
+    end
+
+If backward! is called when in the `first` state, 'on_unavailable_transition' is invoked and workflow stays in a 'first' state.  This
+example surpresses the Workflow::NoTransitionAllowed exception from being raised, if you still want it to be raised you can simply
+call it yourself or return false.
+
+This is particularly useful when you don't want a processes to be aborted due to the workflow being in an unexpected state.
+
 ### Guards
 
 If you want to halt the transition conditionally, you can just raise an

--- a/lib/workflow/specification.rb
+++ b/lib/workflow/specification.rb
@@ -6,7 +6,7 @@ require 'workflow/errors'
 module Workflow
   class Specification
     attr_accessor :states, :initial_state, :meta,
-      :on_transition_proc, :before_transition_proc, :after_transition_proc, :on_error_proc
+      :on_transition_proc, :before_transition_proc, :after_transition_proc, :on_error_proc, :on_unavailable_transition_proc
 
     def initialize(meta = {}, &specification)
       @states = Hash.new
@@ -63,5 +63,10 @@ module Workflow
     def on_error(&proc)
       @on_error_proc = proc
     end
+
+    def on_unavailable_transition(&proc)
+      @on_unavailable_transition_proc = proc
+    end
+
   end
 end

--- a/test/on_unavailable_transition_test.rb
+++ b/test/on_unavailable_transition_test.rb
@@ -1,0 +1,85 @@
+require File.join(File.dirname(__FILE__), 'test_helper')
+require 'workflow'
+
+class OnUnavailableTransitionTest < Test::Unit::TestCase
+
+  class NoUnavailableTransitionBlock
+    attr_reader :unavailable_transitions
+
+    def initialize
+      @unavailable_transitions = {}
+    end
+
+    include Workflow
+    workflow do
+      state :first
+      state :second do
+        event :backward, :transitions_to => :first
+      end
+    end
+  end
+
+  class UnavailableTransitionBlock
+    attr_reader :unavailable_transitions
+
+    def initialize
+      @unavailable_transitions = {}
+    end
+
+    include Workflow
+    workflow do
+      state :first
+      state :second do
+        event :backward, :transitions_to => :first
+      end
+      on_unavailable_transition do |from, to_name, *args|
+        @unavailable_transitions.merge!({:from => from, :to_name => to_name, :args => args})
+      end
+    end
+  end
+
+  class UnavailableTransitionBlockThrowsException
+    attr_reader :unavailable_transitions
+
+    def initialize
+      @unavailable_transitions = {}
+    end
+
+    include Workflow
+    workflow do
+      state :first
+      state :second do
+        event :backward, :transitions_to => :first
+      end
+      on_unavailable_transition do |from, to_name, *args|
+        @unavailable_transitions.merge!({:from => from, :to_name => to_name, :args => args})
+        false
+      end
+    end
+  end
+
+  test 'that NoUnavailableTransitionBlock is raised when no on_unavailable_transition block is defined' do
+    flow = NoUnavailableTransitionBlock.new
+    assert_raise( Workflow::NoTransitionAllowed ) { flow.backward! }
+    assert_equal({}, flow.unavailable_transitions)
+    # transition should not happen
+    assert_equal(true, flow.first?)
+  end
+
+  test 'that on_unavailable_transition block is called when an undefined event is called' do
+    flow = UnavailableTransitionBlock.new
+    assert_nothing_raised { flow.backward! }
+    assert_equal({:from => :first, :to_name => :backward, :args=>[]}, flow.unavailable_transitions)
+    # transition should not happen
+    assert_equal(true, flow.first?)
+  end
+
+  test 'that on_unavailable_transition block is called when an undefined event is called and throws NoUnavailableTransitionBlock as false is returned' do
+    flow = UnavailableTransitionBlockThrowsException.new
+    assert_raise( Workflow::NoTransitionAllowed ) { flow.backward! }
+    assert_equal({:from => :first, :to_name => :backward, :args=>[]}, flow.unavailable_transitions)
+    # transition should not happen
+    assert_equal(true, flow.first?)
+  end
+
+end


### PR DESCRIPTION
I'm looking to use workflow on an existing project and don't want state transitions to throw an error if the workflow is in an unexpected state and the transition is unavailable, I instead want to simply log what occurred so it can be fixed. I've created this feature so I don't have to put in exception handling with each state transition.
