### PR TITLE
Fix AcriveRecord adapter to save the full object state.

### DIFF
--- a/lib/workflow/adapters/active_record.rb
+++ b/lib/workflow/adapters/active_record.rb
@@ -15,8 +15,8 @@ module Workflow
         # On transition the new workflow state is immediately saved in the
         # database.
         def persist_workflow_state(new_value)
-          # Rails 3.1 or newer
-          update_column self.class.workflow_column, new_value
+          write_attribute(self.class.workflow_column, new_value)
+          save!
         end
 
         private

--- a/test/new_versions/persistence_test.rb
+++ b/test/new_versions/persistence_test.rb
@@ -24,6 +24,7 @@ class PersistenceTestOrder < ActiveRecord::Base
 
   attr_accessible :title # protecting all the other attributes
 
+  validates :title, :presence => true
 end
 
 PersistenceTestOrder.logger = Logger.new(STDOUT) # active_record 2.3 expects a logger instance
@@ -55,7 +56,15 @@ class PersistenceTest < ActiveRecordTestCase
     o.title = 'going to change the title'
     assert o.changed?
     o.ship!
-    assert o.changed?, 'title should not be saved and the change still stay pending'
+    assert !o.changed?, 'title should be saved'
+  end
+
+  test 'should raise ActiveRecord::RecordInvalid exception when saving record with failing validations' do
+    o = assert_state 'order6', 'accepted'
+    o.title = nil
+    assert_raise ActiveRecord::RecordInvalid do
+      o.ship!
+    end
   end
 
 end


### PR DESCRIPTION
Also, it is important we use the 'bang' version of save, as otherwise
the state machine would proceed with entering the 'to' state etc.
