### PR TITLE
Support for enumerated state values

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -104,7 +104,11 @@ event (transition) defined for the current state.
 Installation
 ------------
 
-    gem install workflow
+    `gem install workflow`
+    
+    `include Workflow` in your model.
+
+If you're using ActiveRecord, Workflow will by default use a "workflow_state" column on your model.
 
 **Important**: If you're interested in graphing your workflow state machine, you will also need to
 install the `activesupport` and `ruby-graphviz` gems.
@@ -446,6 +450,35 @@ When calling a `device.can_<fire_event>?` check, or attempting a `device.<event>
 * If an `:if` check is present, proceed if it evaluates to true, or drop to the next event.
 * If you've run out of events to check (eg. `battery_level == 0`), then the transition isn't possible.
 
+Enum values or other custom values
+-----------------------------------
+
+If you don't want to store your state as a string column, you can specify the value associated with each state.  YOu can use an int (like an enum) or a shorter string.
+
+Oh, you can 
+
+    Class Foo < ActiveRecord::Base
+      include Workflow
+    
+      workflow do
+        state :one, 1 do
+          event :increment, :transitions_to => :two
+        end
+        state :two, 2
+        on_transition do |from, to, triggering_event, *event_args|
+          Log.info "#{from} -> #{to}"
+        end
+      end
+    end
+
+Your database column will store the values 1, 2, etc.  But you'll still use the state symbols for querying.
+
+    foo = Foo.create
+    foo.current_state # => :one
+    foo.workflow_state # => 1 #You really shouldn't use this column directly...
+    foo.increment!
+    foo.two? # => true
+    foo.workflow_state # => true
 
 Advanced transition hooks
 -------------------------

--- a/README.markdown
+++ b/README.markdown
@@ -255,7 +255,16 @@ custom persistence column easily, e.g. for a legacy database schema:
                                # persistence
     end
 
+You can also set the column name inline into the workflow block:
 
+    class LegacyOrder < ActiveRecord::Base
+      include Workflow
+
+      workflow :foo_bar do
+        state :approved
+        state :pending
+      end
+    end
 
 ### Single table inheritance
 

--- a/README.markdown
+++ b/README.markdown
@@ -453,9 +453,9 @@ When calling a `device.can_<fire_event>?` check, or attempting a `device.<event>
 Enum values or other custom values
 -----------------------------------
 
-If you don't want to store your state as a string column, you can specify the value associated with each state.  YOu can use an int (like an enum) or a shorter string.
+If you don't want to store your state as a string column, you can specify the value associated with each state.  Yu can use an int (like an enum) or a shorter string, or whatever you want.
 
-Oh, you can 
+Just pass the "value" for the state as the second parameter to the "state" method.
 
     Class Foo < ActiveRecord::Base
       include Workflow
@@ -479,6 +479,8 @@ Your database column will store the values 1, 2, etc.  But you'll still use the 
     foo.increment!
     foo.two? # => true
     foo.workflow_state # => true
+
+Hopefully obvious, but if you ever change the value of a state, you'll need to do a migration/address existing records in your data store.  However you are free to change the "name" of a state, willy-nilly.
 
 Advanced transition hooks
 -------------------------

--- a/lib/workflow.rb
+++ b/lib/workflow.rb
@@ -76,9 +76,6 @@ module Workflow
   module InstanceMethods
 
     def current_state
-      if $STOP 
-        require 'pry'; binding.pry
-      end
       loaded_state_value = load_workflow_state
       if loaded_state_value
         loaded_state_name = spec.states.select{|k,v| v.value.to_s == loaded_state_value.to_s}.keys.first

--- a/lib/workflow/adapters/active_record.rb
+++ b/lib/workflow/adapters/active_record.rb
@@ -60,7 +60,7 @@ module Workflow
             end
 
             define_singleton_method("without_#{state}_state") do
-              where.not("#{table_name}.#{self.workflow_column.to_sym} = ?", state.value)
+              where("#{table_name}.#{self.workflow_column.to_sym} != ?", state.value)
             end
           end
         end

--- a/lib/workflow/adapters/active_record.rb
+++ b/lib/workflow/adapters/active_record.rb
@@ -50,8 +50,8 @@ module Workflow
           end
         end
 
-        def workflow_with_scopes(&specification)
-          workflow_without_scopes(&specification)
+        def workflow_with_scopes(column=nil, &specification)
+          workflow_without_scopes(column, &specification)
           states = workflow_spec.states.values
 
           states.each do |state|

--- a/lib/workflow/adapters/active_record.rb
+++ b/lib/workflow/adapters/active_record.rb
@@ -24,10 +24,10 @@ module Workflow
         # Motivation: even if NULL is stored in the workflow_state database column,
         # the current_state is correctly recognized in the Ruby code. The problem
         # arises when you want to SELECT records filtering by the value of initial
-        # state. That's why it is important to save the string with the name of the
+        # state. That's why it is important to save the string with the value of the
         # initial state in all the new records.
         def write_initial_state
-          write_attribute self.class.workflow_column, current_state.to_s
+          write_attribute self.class.workflow_column, current_state.value
         end
       end
 
@@ -56,11 +56,11 @@ module Workflow
 
           states.each do |state|
             define_singleton_method("with_#{state}_state") do
-              where("#{table_name}.#{self.workflow_column.to_sym} = ?", state.to_s)
+              where("#{table_name}.#{self.workflow_column.to_sym} = ?", state.value)
             end
 
             define_singleton_method("without_#{state}_state") do
-              where.not("#{table_name}.#{self.workflow_column.to_sym} = ?", state.to_s)
+              where.not("#{table_name}.#{self.workflow_column.to_sym} = ?", state.value)
             end
           end
         end

--- a/lib/workflow/specification.rb
+++ b/lib/workflow/specification.rb
@@ -20,9 +20,10 @@ module Workflow
 
     private
 
-    def state(name, meta = {:meta => {}}, &events_and_etc)
+    def state(name, value=nil, meta = {:meta => {}}, &events_and_etc)
       # meta[:meta] to keep the API consistent..., gah
-      new_state = Workflow::State.new(name, self, meta[:meta])
+      value ||= name
+      new_state = Workflow::State.new(name, value, self, meta[:meta])
       @initial_state = new_state if @states.empty?
       @states[name.to_sym] = new_state
       @scoped_state = new_state

--- a/lib/workflow/state.rb
+++ b/lib/workflow/state.rb
@@ -1,10 +1,10 @@
 module Workflow
   class State
-    attr_accessor :name, :events, :meta, :on_entry, :on_exit
+    attr_accessor :name, :value, :events, :meta, :on_entry, :on_exit
     attr_reader :spec
 
-    def initialize(name, spec, meta = {})
-      @name, @spec, @events, @meta = name, spec, EventCollection.new, meta
+    def initialize(name, value, spec, meta = {})
+      @name, @value, @spec, @events, @meta = name, value, spec, EventCollection.new, meta
     end
 
     def draw(graph)

--- a/test/active_record_scopes_with_values_test.rb
+++ b/test/active_record_scopes_with_values_test.rb
@@ -1,0 +1,85 @@
+require File.join(File.dirname(__FILE__), 'test_helper')
+
+$VERBOSE = false
+require 'active_record'
+require 'sqlite3'
+require 'workflow'
+
+ActiveRecord::Migration.verbose = false
+
+class EnumArticle < ActiveRecord::Base
+  include Workflow
+
+  workflow do
+    state :new, 1 do
+      event :accept, transitions_to: :accepted
+    end
+    state :accepted, 3
+  end
+end
+
+class ActiveRecordScopesWithValuesTest < ActiveRecordTestCase
+
+  def setup
+    super
+
+    ActiveRecord::Schema.define do
+      create_table :enum_articles do |t|
+        t.string :title
+        t.string :body
+        t.string :blame_reason
+        t.string :reject_reason
+        t.integer :workflow_state
+      end
+    end
+  end
+
+  def assert_state(title, expected_state, klass = Order)
+    o = klass.find_by_title(title)
+    assert_equal expected_state, o.read_attribute(klass.workflow_column)
+    o
+  end
+
+  test 'have "with_new_state" scope' do
+    assert_respond_to EnumArticle, :with_new_state
+  end
+
+  test '"with_new_state" selects matching value' do
+    article = EnumArticle.create
+    assert_equal(article.workflow_state, 1)
+    assert_equal(EnumArticle.with_new_state.all, [article])
+  end
+
+  test 'have "with_accepted_state" scope' do
+    assert_respond_to EnumArticle, :with_accepted_state
+  end
+
+  test '"with_accepted_state" selects matching values' do
+    article = EnumArticle.create
+    article.accept!
+    assert_equal(EnumArticle.with_accepted_state.all, [article])
+  end
+
+  test 'have "without_new_state" scope' do
+    assert_respond_to EnumArticle, :without_new_state
+  end
+
+  test '"without_new_state" filters matching value' do
+    article = EnumArticle.create
+    article.accept!
+    assert_equal(article.workflow_state, 2)
+    assert_equal(EnumArticle.without_new_state.all, [article])
+  end
+
+  test 'have "without_accepted_state" scope' do
+    assert_respond_to EnumArticle, :without_accepted_state
+  end
+
+  test '"without_new_state" filters matching value' do
+    article = EnumArticle.create
+    assert_equal(article.workflow_state, 1)
+    assert_equal(EnumArticle.without_accepted_state.all, [article])
+  end
+
+end
+

--- a/test/active_record_scopes_with_values_test.rb
+++ b/test/active_record_scopes_with_values_test.rb
@@ -34,12 +34,6 @@ class ActiveRecordScopesWithValuesTest < ActiveRecordTestCase
     end
   end
 
-  def assert_state(title, expected_state, klass = Order)
-    o = klass.find_by_title(title)
-    assert_equal expected_state, o.read_attribute(klass.workflow_column)
-    o
-  end
-
   test 'have "with_new_state" scope' do
     assert_respond_to EnumArticle, :with_new_state
   end
@@ -68,7 +62,7 @@ class ActiveRecordScopesWithValuesTest < ActiveRecordTestCase
     article = EnumArticle.create
     article.accept!
     assert_equal(article.workflow_state, 2)
-    assert_equal(EnumArticle.without_new_state.all, [article])
+    assert_equal(EnumArticle.without_new_state, [article])
   end
 
   test 'have "without_accepted_state" scope' do
@@ -78,7 +72,7 @@ class ActiveRecordScopesWithValuesTest < ActiveRecordTestCase
   test '"without_new_state" filters matching value' do
     article = EnumArticle.create
     assert_equal(article.workflow_state, 1)
-    assert_equal(EnumArticle.without_accepted_state.all, [article])
+    assert_equal(EnumArticle.without_accepted_state, [article])
   end
 
 end

--- a/test/active_record_scopes_with_values_test.rb
+++ b/test/active_record_scopes_with_values_test.rb
@@ -61,7 +61,7 @@ class ActiveRecordScopesWithValuesTest < ActiveRecordTestCase
   test '"without_new_state" filters matching value' do
     article = EnumArticle.create
     article.accept!
-    assert_equal(article.workflow_state, 2)
+    assert_equal(article.workflow_state, 3)
     assert_equal(EnumArticle.without_new_state, [article])
   end
 
@@ -69,7 +69,7 @@ class ActiveRecordScopesWithValuesTest < ActiveRecordTestCase
     assert_respond_to EnumArticle, :without_accepted_state
   end
 
-  test '"without_new_state" filters matching value' do
+  test '"without_accepted_state" filters matching value' do
     article = EnumArticle.create
     assert_equal(article.workflow_state, 1)
     assert_equal(EnumArticle.without_accepted_state, [article])

--- a/test/adapter_hook_test.rb
+++ b/test/adapter_hook_test.rb
@@ -46,7 +46,6 @@ class AdapterHookTest < ActiveRecordTestCase
     hook = ChosenByHookAdapter.create
     assert hook.initial?
     hook.progress!
-    require 'pry'; binding.pry
     assert_equal hook.foo, :last, 'should have "persisted" with custom adapter'
     assert ChosenByHookAdapter.find(hook.id).initial?, 'should not have persisted via ActiveRecord'
   end

--- a/test/adapter_hook_test.rb
+++ b/test/adapter_hook_test.rb
@@ -46,7 +46,8 @@ class AdapterHookTest < ActiveRecordTestCase
     hook = ChosenByHookAdapter.create
     assert hook.initial?
     hook.progress!
-    assert_equal hook.foo, 'last', 'should have "persisted" with custom adapter'
+    require 'pry'; binding.pry
+    assert_equal hook.foo, :last, 'should have "persisted" with custom adapter'
     assert ChosenByHookAdapter.find(hook.id).initial?, 'should not have persisted via ActiveRecord'
   end
 end

--- a/test/attr_protected_test.rb
+++ b/test/attr_protected_test.rb
@@ -60,13 +60,13 @@ class AttrProtectedTest < ActiveRecordTestCase
 
   test 'cannot mass-assign workflow_state if attr_protected' do
      o = AttrProtectedTestOrder.find_by_title('order1')
-     assert_equal 'submitted', o.read_attribute(:workflow_state)
+     assert_equal 'submitted', o.read_attribute(:workflow_state).to_s
      AttrProtectedTestOrder.logger.level = Logger::ERROR # ignore warnings
      o.update_attributes :workflow_state => 'some_bad_value'
      AttrProtectedTestOrder.logger.level = Logger::WARN
-     assert_equal 'submitted', o.read_attribute(:workflow_state)
+     assert_equal 'submitted', o.read_attribute(:workflow_state).to_s
      o.update_attribute :workflow_state, 'some_overridden_value'
-     assert_equal 'some_overridden_value', o.read_attribute(:workflow_state)
+     assert_equal 'some_overridden_value', o.read_attribute(:workflow_state).to_s
    end
 
   test 'immediately save the new workflow_state on state machine transition' do

--- a/test/enum_values_in_memory_test.rb
+++ b/test/enum_values_in_memory_test.rb
@@ -1,0 +1,23 @@
+class EnumValuesInMemoryTest < ActiveRecordTestCase
+  test 'that the value of the state is persisted instead of the name' do 
+
+    class EnumFlow
+      attr_reader :workflow_state
+      include Workflow
+
+      workflow do
+        state :first, 1 do
+          event :forward, :transitions_to => :second
+        end
+        state :second, 2 do
+          event :back, :transitions_to => :first
+        end
+      end
+    end
+
+    flow = EnumFlow.new
+    flow.forward!
+    assert flow.workflow_state == 2
+    assert flow.second?
+  end
+end

--- a/test/enum_values_test.rb
+++ b/test/enum_values_test.rb
@@ -1,0 +1,30 @@
+require File.join(File.dirname(__FILE__), 'test_helper')
+require 'workflow'
+
+class EnumValuesTest < ActiveRecordTestCase
+  test 'that the value of the state is persisted instead of the name' do
+  
+    ActiveRecord::Schema.define do
+      create_table(:active_enum_flows) { |t| t.integer :state }
+    end
+
+    class ActiveEnumFlow < ActiveRecord::Base
+      include Workflow
+      workflow_column :state
+
+      workflow do
+        state :first, 1 do
+          event :forward, :transitions_to => :second
+        end
+        state :second, 2 do
+          event :back, :transitions_to => :first
+        end
+      end
+    end
+
+    flow = ActiveEnumFlow.create
+    flow.forward!
+    assert flow.state == 2
+    assert flow.second?
+  end
+end

--- a/test/incline_column_test.rb
+++ b/test/incline_column_test.rb
@@ -1,0 +1,54 @@
+require File.join(File.dirname(__FILE__), 'test_helper')
+
+$VERBOSE = false
+require 'active_record'
+require 'sqlite3'
+require 'workflow'
+
+ActiveRecord::Migration.verbose = false
+
+class EnumArticleHi < ActiveRecord::Base
+  include Workflow
+
+  workflow :inline_column_hi do
+    state :new, 1 do
+      event :accept, transitions_to: :accepted
+    end
+    state :accepted, 3
+  end
+end
+
+class InlineColumnTest < ActiveRecordTestCase
+
+  def setup
+    super
+
+    ActiveRecord::Schema.define do
+      create_table :enum_article_his do |t|
+        t.string :title
+        t.string :body
+        t.string :blame_reason
+        t.string :reject_reason
+        t.integer :inline_column_hi
+      end
+    end
+  end
+
+  test '"with_new_state" selects matching value' do
+    article = EnumArticleHi.create
+    assert_equal(article.inline_column_hi, 1)
+    article.accept!
+    assert_equal(article.inline_column_hi, 3)
+  end
+
+  test 'allows passing in state value on create' do
+    article = EnumArticleHi.create(inline_column_hi: 3)
+    assert_equal(article.inline_column_hi, 3)
+  end
+
+  test 'allows passing in state name on create' do
+    article = EnumArticleHi.create(inline_column_hi: :accepted)
+    assert_equal(article.inline_column_hi, 3)
+  end
+end
+

--- a/test/main_test.rb
+++ b/test/main_test.rb
@@ -235,7 +235,7 @@ class MainTest < ActiveRecordTestCase
 
   test 'initial state immediately set as ActiveRecord attribute for new objects' do
     o = Order.create(:title => 'new object')
-    assert_equal 'submitted', o.read_attribute(:workflow_state)
+    assert_equal 'submitted', o.read_attribute(:workflow_state).to_s
   end
 
   test 'question methods for state' do

--- a/test/main_test.rb
+++ b/test/main_test.rb
@@ -210,8 +210,8 @@ class MainTest < ActiveRecordTestCase
     c.class_eval do
       include Workflow
       workflow do
-        state :main, :meta => {:importance => 8}
-        state :supplemental, :meta => {:importance => 1}
+        state :main, 1, :meta => {:importance => 8}
+        state :supplemental, 2, :meta => {:importance => 1}
       end
     end
     assert_equal 1, c.workflow_spec.states[:supplemental].meta[:importance]

--- a/workflow.gemspec
+++ b/workflow.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'mocha'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'test-unit'
+  gem.add_development_dependency 'pry-rails'
   gem.add_development_dependency 'ruby-graphviz', ['~> 1.0.0']
   
   gem.required_ruby_version = '>= 1.9.2'

--- a/workflow.gemspec
+++ b/workflow.gemspec
@@ -24,9 +24,11 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rdoc',    [">= 3.12"]
   gem.add_development_dependency 'bundler', [">= 1.0.0"]
   gem.add_development_dependency 'activerecord'
+  gem.add_development_dependency 'protected_attributes'
   gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'mocha'
   gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'test-unit'
   gem.add_development_dependency 'ruby-graphviz', ['~> 1.0.0']
   
   gem.required_ruby_version = '>= 1.9.2'


### PR DESCRIPTION
We can now store an integer in the database/store to persist state, rather than a string
benefits to this:
1. Storing raw strings for state columns is generally not best practice.  Now we don't have to think about it.
2. We don't want the length of a state's name to be limited based on a db column size (rather it should be limited by developer sensibility)
3. We would like to change the name of a state at any time to make it more expressive, without needing to fixup/migrate underlying data.  

This is somewhat hacky, so suggestions are welcome.  But tests are good, and scopes are fully supported. 
