### PR TITLE
Do not attempt to draw metadata

### DIFF
--- a/lib/workflow/state.rb
+++ b/lib/workflow/state.rb
@@ -15,7 +15,7 @@ module Workflow
         :shape => 'ellipse'
       }
 
-      node = graph.add_nodes(to_s, defaults.merge(meta))
+      node = graph.add_nodes(to_s, defaults)
 
       # Add open arrow for initial state
       # graph.add_edge(graph.add_node('starting_state', :shape => 'point'), node) if initial?

--- a/test/main_test.rb
+++ b/test/main_test.rb
@@ -13,14 +13,14 @@ ActiveRecord::Migration.verbose = false
 class Order < ActiveRecord::Base
   include Workflow
   workflow do
-    state :submitted do
+    state :submitted, :meta => {refundable: true} do
       event :accept, :transitions_to => :accepted, :meta => {:weight => 8} do |reviewer, args|
       end
     end
-    state :accepted do
+    state :accepted, :meta => {refundable: true} do
       event :ship, :transitions_to => :shipped
     end
-    state :shipped
+    state :shipped, :meta => {refundable: false}
   end
 end
 


### PR DESCRIPTION
We should not assume that model metadata has anything to do with graphviz output. Stop passing the metadata to Graphviz.

The modified test demonstrates the bug by failing unless the fix is applied.

Fixes issue #128 
