### PR TITLE
when process an unsupported event on a state, also trigger the on_error hook

### DIFF
--- a/lib/workflow.rb
+++ b/lib/workflow.rb
@@ -179,7 +179,7 @@ module Workflow
 
     def run_on_error(error, from, to, event, *args)
       if spec.on_error_proc
-        instance_exec(error, from.name, to.name, event, *args, &spec.on_error_proc)
+        instance_exec(error, from.name, ( to.name rescue nil ), event, *args, &spec.on_error_proc)
         halt(error.message)
       else
         raise error

--- a/lib/workflow.rb
+++ b/lib/workflow.rb
@@ -95,9 +95,13 @@ module Workflow
 
     def process_event!(name, *args)
       event = current_state.events.first_applicable(name, self)
-      raise NoTransitionAllowed.new(
-        "There is no event #{name.to_sym} defined for the #{current_state} state") \
-        if event.nil?
+      if event.nil?
+        run_on_error(NoTransitionAllowed.new(
+          "There is no event #{name.to_sym} defined for the #{current_state} state"), 
+          current_state, 
+          nil, name, *args)
+        return false
+      end
       @halted_because = nil
       @halted = false
 


### PR DESCRIPTION
currently when process an unsupported event on a state, workflow will raise NoTransitionAllowed error but without triggering the on_error hook, so I cannot do centralized error handling, I must check the event or rescue all event triggering everywhere to handle NoTransitionAllowed exception.
This PR will catch the exception to on_error hook, so I can do error handling in the hook.
