### PR TITLE
Pass event name and args to #persist_workflow_state

### DIFF
--- a/lib/workflow.rb
+++ b/lib/workflow.rb
@@ -121,7 +121,7 @@ module Workflow
 
       run_on_exit(from, to, name, *args)
 
-      transition_value = persist_workflow_state to.to_s
+      transition_value = persist_workflow_state!(from, to, name, *args)
 
       run_on_entry(to, from, name, *args)
 
@@ -184,6 +184,14 @@ module Workflow
 
     def run_on_transition(from, to, event, *args)
       instance_exec(from.name, to.name, event, *args, &spec.on_transition_proc) if spec.on_transition_proc
+    end
+
+    def persist_workflow_state!(from, to, event, *args)
+      if self.method(:persist_workflow_state).arity == 1
+        persist_workflow_state(to.to_s)
+      else
+        persist_workflow_state(to.to_s, event, *args)
+      end
     end
 
     def run_after_transition(from, to, event, *args)


### PR DESCRIPTION
I'm using the Vestal Versions gem (https://github.com/laserlemon/vestal_versions) to version user changes in models. I also need to version state changes and attach the user that changed the state to the version change.

I have the user available in the event args. This change basically allows me to do the following:

``` ruby
  def persist_workflow_state(new_state, event, *event_args)
    current_user = event_args[0] && event_args[0][:user]
    self.update_attributes(state: new_state, updated_by: current_user)
  end
```
