### PR TITLE
Added safeguard to ensure proper method undefinition

### DIFF
--- a/lib/workflow.rb
+++ b/lib/workflow.rb
@@ -41,8 +41,8 @@ module Workflow
           state.events.flat.each do |event|
             event_name = event.name
             module_eval do
-              undef_method "#{event_name}!".to_sym
-              undef_method "can_#{event_name}?"
+              undef_method("#{event_name}!") if method_defined? "#{event_name}!"
+              undef_method("can_#{event_name}?") if method_defined? "can_#{event_name}?"
             end
           end
         end

--- a/test/inheritance_test.rb
+++ b/test/inheritance_test.rb
@@ -57,4 +57,38 @@ class InheritanceTest < ActiveRecordTestCase
     methods_with_bang = non_trivial_methods.select {|m| m =~ /!$/}
     sort_sym_array(methods_with_bang).map {|m| m.to_sym}
   end
+
+  test 'inheritance with workflow states with same event names' do
+    class Mail
+      include Workflow
+      workflow do
+        state :unread do
+          event :open, transitions_to: :read
+          event :burn, transitions_to: :burned
+        end
+        state :read do
+          event :burn, transitions_to: :burned
+        end
+        state :burned
+      end
+    end
+
+    assert_nothing_raised { create_child_class }
+  end
+
+  def create_child_class
+    Class.new(Mail) do
+      include Workflow
+      workflow do
+        state :unread do
+          event :open, transitions_to: :read
+          event :delete, transitions_to: :deleted
+        end
+        state :read do
+          event :delete, transitions_to: :deleted
+        end
+        state :deleted
+      end
+    end
+  end
 end


### PR DESCRIPTION
This code ensures that a class structure as:

``` ruby
class MessageParent
  include Workflow
  workflow do
    state :state1 do
      event :event1, transitions_to: :state2
      event :event2, transitions_to: :state3
    end
    state :state2 do
      event :event2, transitions_to: :state3
    end
    state :state3
  end
end

class MessageChild < MessageParent
  include Workflow
  workflow do
    state :state4 do
      event :event3, transitions_to: :state5
    end
    state :state5
  end
end
```

Doesen´t raise an exception like:

```
undefined method `event2!' for class `MessageChild'
```

This happens because `.workflow` method tries to undefine the same event more than once.
