### PR TITLE
Json load

### DIFF
--- a/lib/workflow.rb
+++ b/lib/workflow.rb
@@ -23,6 +23,10 @@ module Workflow
       assign_workflow Specification.new(Hash.new, &specification)
     end
 
+    def reassign_workflow!
+      assign_workflow workflow_spec
+    end
+
     private
 
     # Creates the convinience methods like `my_transition!`

--- a/lib/workflow/event.rb
+++ b/lib/workflow/event.rb
@@ -34,5 +34,25 @@ module Workflow
     def to_s
       @name.to_s
     end
+
+    def as_json(*)
+      {
+          name: name,
+          transitions_to: transitions_to,
+          meta: meta,
+          action: action,
+          condition: condition
+      }
+    end
+
+    def from_json!(json_obj)
+      @name = json_obj['name'].to_sym
+      @transitions_to = json_obj['transitions_to'].to_sym
+      @meta = json_obj['meta']
+      @action = json_obj['action']
+
+      # TODO: Pending condition object. Review action...
+      #@condition = json_obj[:condition]
+    end
   end
 end

--- a/lib/workflow/event_collection.rb
+++ b/lib/workflow/event_collection.rb
@@ -32,5 +32,14 @@ module Workflow
       end
     end
 
+    def from_json!(json_obj)
+      json_obj.each do |key, val_array|
+        val_array.each do |val|
+          new_event = Workflow::Event.new(nil,'dummy')
+          new_event.from_json!(val)
+          push(key,new_event)
+        end
+      end
+    end
   end
 end

--- a/lib/workflow/state.rb
+++ b/lib/workflow/state.rb
@@ -40,5 +40,20 @@ module Workflow
     def to_sym
       name.to_sym
     end
+
+    def as_json(*)
+      {
+          name: name,
+          meta: meta,
+          events: events
+      }
+    end
+
+    def from_json!(json_obj)
+      @name = json_obj['name'].to_sym
+      @meta = json_obj['meta']
+      @events = Workflow::EventCollection.new
+      @events.from_json!(json_obj['events']) if json_obj['events']
+    end
   end
 end

--- a/lib/workflow/version.rb
+++ b/lib/workflow/version.rb
@@ -1,3 +1,3 @@
 module Workflow
-  VERSION = "1.3.0"
+  VERSION = "1.3.0.3"
 end

--- a/test/json_load_test.rb
+++ b/test/json_load_test.rb
@@ -1,0 +1,149 @@
+require File.join(File.dirname(__FILE__), 'test_helper')
+
+$VERBOSE = false
+require 'active_record'
+require 'sqlite3'
+require 'workflow'
+require 'mocha/setup'
+#require 'stringio'
+#require 'ruby-debug'
+
+#ActiveRecord::Migration.verbose = false
+
+class Order < ActiveRecord::Base
+  include Workflow
+  workflow do # empty workflow that will be loaded from json
+  end
+end
+
+class JsonLoadTest < ActiveRecordTestCase
+
+  def setup
+    super
+
+    ActiveRecord::Schema.define do
+      create_table :orders do |t|
+        t.string :title, :null => false
+        t.string :workflow_state
+      end
+    end
+
+    exec "INSERT INTO orders(title, workflow_state) VALUES('some order', 'open')"
+
+    Order.workflow_spec.from_json_file!('workflows/order.wf')
+    Order.reassign_workflow!
+  end
+
+  def assert_state(title, expected_state, klass = Order)
+    o = klass.find_by_title(title)
+    assert_equal expected_state, o.read_attribute(klass.workflow_column)
+    o
+  end
+
+  test 'order workflow load from json file' do
+    assert Order.workflow_spec.from_json_file!('workflows/order.wf')
+    assert_not_nil Order.workflow_spec.initial_state
+    assert_equal Order.workflow_spec.initial_state.class , Workflow::State
+  end
+
+  test 'number of state keys is the expected one after order workflow load from json file' do
+    assert_equal Order.workflow_spec.states.keys.length, 5
+  end
+
+  test 'number of state values is the expected one after order workflow load from json file' do
+    assert_equal Order.workflow_spec.states.values.length, 5
+  end
+
+  test 'State class is the expected one after order workflow load from json file' do
+    assert_equal Order.workflow_spec.states.values.first.class, Workflow::State
+  end
+
+  test 'State name class is the expected one after order workflow load from json file' do
+    assert_equal Order.workflow_spec.states.values.first.name.class, Symbol
+  end
+
+  test 'State Meta attibute class is the expected one after order workflow load from json file' do
+    assert_equal Order.workflow_spec.states.values.first.meta.class, Hash
+  end
+
+  test 'State Meta attribute is loaded after order workflow load from json file' do
+    assert_equal Order.workflow_spec.states.values.first.meta.keys.length, 0
+  end
+
+  test 'Workflow specification is assigned to State after order workflow load from json file' do
+    assert_equal Order.workflow_spec.states.values.first.spec.class, Workflow::Specification
+  end
+
+  test 'Workflow specification assigned to State after order workflow load from json file is the workflow_spec' do
+    assert_equal Order.workflow_spec.states.values.first.spec, Order.workflow_spec
+  end
+
+  test 'Workflow events list class is the expected one after order workflow load from json file is the workflow_spec' do
+    assert_equal Order.workflow_spec.states.values.first.events.class, Workflow::EventCollection
+  end
+
+  test 'Workflow event class is the expected one after order workflow load from json file is the workflow_spec' do
+    assert_equal Order.workflow_spec.states.values.first.events.values.first[0].class, Workflow::Event
+  end
+
+  test 'Workflow event class for name is the expected one after order workflow load from json file is the workflow_spec' do
+    assert_equal Order.workflow_spec.states.values.first.events.values.first[0].name.class, Symbol
+  end
+
+  test 'expected number of events per state after order workflow load from json file is the workflow_spec' do
+    assert_equal Order.workflow_spec.states[:open].events.length, 1
+    assert_equal Order.workflow_spec.states[:awaiting_review].events.length, 1
+    assert_equal Order.workflow_spec.states[:being_reviewed].events.length, 2
+    assert_equal Order.workflow_spec.states[:accepted].events.length, 0
+    assert_equal Order.workflow_spec.states[:rejected].events.length, 0
+  end
+
+  test 'existing methods per events' do
+    o = assert_state('some order','open')
+    assert o.method_exists?(:contacted!)
+    assert o.method_exists?(:review!)
+    assert o.method_exists?(:accept!)
+    assert o.method_exists?(:can_contacted?)
+    assert o.method_exists?(:can_review?)
+    assert o.method_exists?(:can_accept?)
+    assert o.method_exists?(:open?)
+    assert o.method_exists?(:awaiting_review?)
+    assert o.method_exists?(:being_reviewed?)
+    assert o.method_exists?(:accepted?)
+    assert o.method_exists?(:rejected?)
+  end
+
+  test 'validate state flow 1 after order workflow load from json file is the workflow_spec' do
+    o = assert_state('some order','open')
+    o.contacted!
+    o = assert_state('some order','awaiting_review')
+    o.review!
+    o = assert_state('some order','being_reviewed')
+    o.accept!
+    assert_state('some order','accepted')
+  end
+
+  test 'validate state flow 2 after order workflow load from json file is the workflow_spec' do
+    o = assert_state('some order','open')
+    o.contacted!
+    o = assert_state('some order','awaiting_review')
+    o.review!
+    o = assert_state('some order','being_reviewed')
+    o.reject!
+    assert_state('some order','rejected')
+  end
+  
+  test 'Loaded Order workflow persists as JSON 2' do
+    assert_equal Order.workflow_spec.to_json, '{"states":{"open":{"name":"open","meta":{},"events":'\
+    '{"contacted":[{"name":"contacted","transitions_to":"awaiting_review","meta":{},"action":null,'\
+    '"condition":null}]}},"awaiting_review":{"name":"awaiting_review","meta":{},"events":{"review":'\
+    '[{"name":"review","transitions_to":"being_reviewed","meta":{},"action":null,"condition":null}]}},'\
+    '"being_reviewed":{"name":"being_reviewed","meta":{},"events":{"accept":[{"name":"accept","transitions_to":'\
+    '"accepted","meta":{},"action":null,"condition":null}],"reject":[{"name":"reject","transitions_to":"rejected",'\
+    '"meta":{},"action":null,"condition":null}]}},"accepted":{"name":"accepted","meta":{},"events":{}},"rejected":'\
+    '{"name":"rejected","meta":{},"events":{}}},"initial_state":{"name":"open","meta":{},"events":{"contacted":'\
+    '[{"name":"contacted","transitions_to":"awaiting_review","meta":{},"action":null,"condition":null}]}},"meta":{}}'
+  end
+
+end
+

--- a/test/main_test.rb
+++ b/test/main_test.rb
@@ -98,6 +98,32 @@ class MainTest < ActiveRecordTestCase
     o
   end
 
+  test 'Order workflow persists as JSON' do
+    assert_equal Order.workflow_spec.to_json, '{"states":{"submitted":{"name":"submitted","meta":{},"events":{"accept":'\
+    '[{"name":"accept","transitions_to":"accepted","meta":{"weight":8},"action":{},"condition":null}]}},'\
+    '"accepted":{"name":"accepted","meta":{},"events":{"ship":[{"name":"ship","transitions_to":"shipped",'\
+    '"meta":{},"action":null,"condition":null}]}},"shipped":{"name":"shipped","meta":{},"events":{}}},'\
+    '"initial_state":{"name":"submitted","meta":{},"events":{"accept":[{"name":"accept","transitions_to":"accepted",'\
+    '"meta":{"weight":8},"action":{},"condition":null}]}},"meta":{}}'
+  end
+
+  test 'LegacyOrder workflow persists as JSON' do
+    assert_equal LegacyOrder.workflow_spec.to_json, '{"states":{"submitted":{"name":"submitted","meta":{},'\
+    '"events":{"accept":[{"name":"accept","transitions_to":"accepted","meta":{"weight":8},"action":{},'\
+    '"condition":null}]}},"accepted":{"name":"accepted","meta":{},"events":{"ship":[{"name":"ship",'\
+    '"transitions_to":"shipped","meta":{},"action":null,"condition":null}]}},"shipped":{"name":"shipped",'\
+    '"meta":{},"events":{}}},"initial_state":{"name":"submitted","meta":{},"events":{"accept":[{"name":"accept",'\
+    '"transitions_to":"accepted","meta":{"weight":8},"action":{},"condition":null}]}},"meta":{}}'
+  end
+
+  test 'Image workflow persists as JSON' do
+    assert_equal Image.workflow_spec.to_json, '{"states":{"unconverted":{"name":"unconverted",'\
+    '"meta":{},"events":{"convert":[{"name":"convert","transitions_to":"converted","meta":{},"action":null,'\
+    '"condition":null}]}},"converted":{"name":"converted","meta":{},"events":{}}},"initial_state":'\
+    '{"name":"unconverted","meta":{},"events":{"convert":[{"name":"convert","transitions_to":"converted",'\
+    '"meta":{},"action":null,"condition":null}]}},"meta":{}}'
+  end
+
   test 'immediately save the new workflow_state on state machine transition' do
     o = assert_state 'some order', 'accepted'
     assert o.ship!

--- a/test/workflows/order.wf
+++ b/test/workflows/order.wf
@@ -1,0 +1,84 @@
+{
+  "states": {
+    "open": {
+      "name": "open",
+      "meta": {},
+      "events": {
+        "contacted": [
+          {
+            "name": "contacted",
+            "transitions_to": "awaiting_review",
+            "meta": {},
+            "action": null,
+            "condition": null
+          }
+        ]
+      }
+    },
+    "awaiting_review": {
+      "name": "awaiting_review",
+      "meta": {},
+      "events": {
+        "review": [
+          {
+            "name": "review",
+            "transitions_to": "being_reviewed",
+            "meta": {},
+            "action": null,
+            "condition": null
+          }
+        ]
+      }
+    },
+    "being_reviewed": {
+      "name": "being_reviewed",
+      "meta": {},
+      "events": {
+        "accept": [
+          {
+            "name": "accept",
+            "transitions_to": "accepted",
+            "meta": {},
+            "action": null,
+            "condition": null
+          }
+        ],
+        "reject": [
+          {
+            "name": "reject",
+            "transitions_to": "rejected",
+            "meta": {},
+            "action": null,
+            "condition": null
+          }
+        ]
+      }
+    },
+    "accepted": {
+      "name": "accepted",
+      "meta": {},
+      "events": {}
+    },
+    "rejected": {
+      "name": "rejected",
+      "meta": {},
+      "events": {}
+    }
+  },
+  "initial_state": {
+    "name": "open",
+    "meta": {},
+    "events": {
+      "contacted": [
+        {
+          "name": "contacted",
+          "transitions_to": "awaiting_review",
+          "meta": {},
+          "action": null,
+          "condition": null
+        }
+      ]
+    }
+  },
+  "meta": {}
+}


### PR DESCRIPTION
Hi, I have been working in this change for some time in order to be able to read and write workflow configuration from externalized json files. 

This is something I find quite valuable for a personal project I am working on. This functionality I am sending will leverage (not in this PR yet) to update and maintain the workflow design using a UI (e.g a browser HTML5 canvas component that could generate json format that will ultimately update the workflow definition)

This PR reads json workflow configuration from files but future PRs could keep external models in NOSQL databases (e.g MongoDB)

I hope you like this PR and you accept to merge it in the main branch. I have created specific tests for this functionality available under tests/json_load_test.rb 

Usage from test/json_load_test.rb

Order.workflow_spec.from_json_file!('workflows/order.wf')
Order.reassign_workflow!
