### PR TITLE
Wrap state transitions in a locking transaction

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -238,6 +238,19 @@ states names:
     # returns all orders with `pending` state
     Order.with_pending_state
 
+### Wrap State Transition in a locking transaction
+
+Wrap your transition in a locking transaction to ensure that any exceptions
+raised later in the transition sequence will roll back earlier changes made to
+the record:
+
+    class Order < ActiveRecord::Base
+      include Workflow
+      workflow transactional: true do
+        state :approved
+        state :pending
+      end
+    end
 
 ### Custom workflow database column
 
@@ -790,4 +803,3 @@ Copyright (c) 2007-2008 Ryan Allen, FlashDen Pty Ltd
 Based on the work of Ryan Allen and Scott Barron
 
 Licensed under MIT license, see the MIT-LICENSE file.
-

--- a/lib/workflow/adapters/active_record.rb
+++ b/lib/workflow/adapters/active_record.rb
@@ -25,7 +25,7 @@ module Workflow
         private
 
         def transition_wrapper(&block)
-          if self.class.class_variable_get(TRANSACTIONAL_TRANSITIONS_CVAR)
+          if self.class.transactional_transitions?
             with_lock(& block)
           else
             yield
@@ -61,9 +61,15 @@ module Workflow
           end
         end
 
+        def transactional_transitions?
+          class_variable_defined?(TRANSACTIONAL_TRANSITIONS_CVAR) &&
+          class_variable_get(TRANSACTIONAL_TRANSITIONS_CVAR)
+        end
+
         def workflow_with_scopes(meta=nil, &specification)
           meta ||= Hash.new
-          self.class_variable_set TRANSACTIONAL_TRANSITIONS_CVAR, !!meta.delete(TRANSACTIONAL_TRANSITIONS_KEY)
+
+          class_variable_set TRANSACTIONAL_TRANSITIONS_CVAR, !!meta.delete(TRANSACTIONAL_TRANSITIONS_KEY)
           workflow_without_scopes(meta, &specification)
           states = workflow_spec.states.values
 

--- a/test/advanced_examples_test.rb
+++ b/test/advanced_examples_test.rb
@@ -124,7 +124,7 @@ class AdvanceExamplesTest < ActiveRecordTestCase
     assert_equal nil, a.title
     a.process_event! :submit, {title: 'Article Title'}
     assert_equal 'Article Title', a.title
-    assert_false a.title_changed?
+    assert !a.title_changed?
   end
 
   test "Changes Rolled Back On Error For Transactional Workflow" do
@@ -133,7 +133,7 @@ class AdvanceExamplesTest < ActiveRecordTestCase
       a.process_event! :submit, {title: 'Invalid Title'}
     end
     assert_equal 'Invalid Title', a.title # Note that the title was set
-    assert_true a.rolled_back
+    assert a.rolled_back
     a.reload
     assert_nil a.title # But the change was not persisted.
   end


### PR DESCRIPTION
Motivation:
1) For databases that support row-level locking, prevent simultaneous changes to the same record
2) Allow for after_transition to trigger a rollback of the state change or any changes
   that were persisted in `before_transition` or `on_transition`.