### PR TITLE
Rename module Scopes to the more conventional ClassMethods

### DIFF
--- a/lib/workflow/adapters/active_record.rb
+++ b/lib/workflow/adapters/active_record.rb
@@ -3,7 +3,7 @@ module Workflow
     module ActiveRecord
       def self.included(klass)
         klass.send :include, Adapter::ActiveRecord::InstanceMethods
-        klass.send :extend, Adapter::ActiveRecord::Scopes
+        klass.send :extend, Adapter::ActiveRecord::ClassMethods
         klass.before_validation :write_initial_state
       end
 
@@ -42,7 +42,7 @@ module Workflow
       # Example above just adds `where(:state_column_name => 'pending')` or
       # `where.not(:state_column_name => 'pending')` to AR query and returns
       # ActiveRecord::Relation.
-      module Scopes
+      module ClassMethods
         def self.extended(object)
           class << object
             alias_method :workflow_without_scopes, :workflow unless method_defined?(:workflow_without_scopes)


### PR DESCRIPTION
To avoid altering module hierarchies on people's apps, the module named `Scope` can be renamed to `ClassMethods`, which is pretty conventional and is less likely to cause name collisions.

Here's the issue we've experienced in our Rails app, where we use Rails' autoloading algorithm and we have a convention of having scopes on a separate module for each model that we call `Scopes`, like:
```ruby
# app/models/blog/scopes.rb
module Blog::Scopes
  extend ActiveSupport::Concern

  included do
    scope :recent, -> { order('created_at DESC').limit(10) }
  end
end
```
```ruby
# app/models/blog.rb
class Blog < ActiveRecord::Base
  include Workflow
  include Blog::Scopes
end
```
Then we run into this issue
```ruby
Blog.recent
# => NoMethodError: undefined method `recent' for #<Class:0x007fe5c0d95ca8>
```

When the line that includes `Blog::Scopes` is executed, we expect Rails' autoloader to go and load `app/models/blog/scopes.rb`. However, this does not happen because the constant already exists on `Workflow::Adapter::ActiveRecord::Scopes` which was included in `Blog`.

We started experiencing this issue when we upgraded from version 0.8.7 to 1.2.0. Before, the constant `Blog::Scopes` could not be resolved so it was autoloaded.

We can fix this by explicitly requiring `blog/scopes`. However, this a surprising behavior that requires a comment in code to be explained. We believe it'd be less surprising if the gem's constant was named `ClassMethods`, like many other modules conventionally do in the Rails community.

The change is very mild and involves no functional changes, just a rename to avoid name collision.