### PR TITLE
Use Object#singleton_class to retrieve the workflow_spec

### DIFF
--- a/lib/workflow.rb
+++ b/lib/workflow.rb
@@ -142,12 +142,10 @@ module Workflow
     end
 
     def spec
-      # check the singleton class first
-      class << self
-        return workflow_spec if workflow_spec
-      end
-
+      ws = singleton_class.workflow_spec
+      return ws if ws
       c = self.class
+
       # using a simple loop instead of class_inheritable_accessor to avoid
       # dependency on Rails' ActiveSupport
       until c.workflow_spec || !(c.include? Workflow)


### PR DESCRIPTION
Opening classes is not recommended for actions done repeatedly
because:
  - it invalidates mri method cache
  - it triggers ruby :end Tracepoint's that can be used for profiling
  and metaprogramming
