### PR TITLE
Add State#in?

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -90,6 +90,10 @@ of possible events and other meta information:
         @transitions_to=:awaiting_review, @name=:submit, @meta={}>},
       name:new, meta{}
 
+Use `current_state` to check against a list of state symbols:
+
+    article.current_state.in? %i(new awaiting_review)
+
 On Ruby 1.9 and above, you can check whether a state comes before or
 after another state (by the order they were defined):
 
@@ -806,4 +810,3 @@ Copyright (c) 2007-2008 Ryan Allen, FlashDen Pty Ltd
 Based on the work of Ryan Allen and Scott Barron
 
 Licensed under MIT license, see the MIT-LICENSE file.
-

--- a/lib/workflow/state.rb
+++ b/lib/workflow/state.rb
@@ -23,6 +23,9 @@ module Workflow
       node
     end
 
+    def in?(states)
+      states.include? self.to_sym
+    end
 
     if RUBY_VERSION >= '1.9'
       include Comparable

--- a/test/new_versions/compare_states_test.rb
+++ b/test/new_versions/compare_states_test.rb
@@ -16,7 +16,6 @@ class ComparableStatesOrder
 end
 
 class CompareStatesTest < Test::Unit::TestCase
-
   test 'compare states' do
     o = ComparableStatesOrder.new
     o.accept!
@@ -29,4 +28,10 @@ class CompareStatesTest < Test::Unit::TestCase
     end
   end
 
+  test 'State#in?' do
+    o = ComparableStatesOrder.new
+    o.accept!
+    assert o.current_state.in?([:accepted, :shipped])
+    assert !o.current_state.in?([:submitted, :shipped])
+  end
 end


### PR DESCRIPTION
A little convenience method to do the following:

```
article.current_state.in? %i(new awaiting_review)
# instead of
%i(new awaiting_review).include? article.current_state.to_sym
```

Shouldn't break anything, but allows to write more expressive conditions.