### PR TITLE
Fix papertrail integration

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -218,6 +218,8 @@ and include the workflow mixin in your model class as usual:
     class Order < ActiveRecord::Base
       include Workflow
       workflow do
+        with_callbacks # optionally invoke update callbacks with state
+transition
         # list states and transitions here
       end
     end

--- a/lib/workflow/adapters/active_record.rb
+++ b/lib/workflow/adapters/active_record.rb
@@ -16,7 +16,8 @@ module Workflow
         # database.
         def persist_workflow_state(new_value)
           # Rails 3.1 or newer
-          if self.class.workflow_spec && self.class.workflow_spec.with_callbacks
+          if self.class.workflow_spec &&
+              self.class.workflow_spec.include_callbacks
             run_callbacks :update do
               self[self.class.workflow_column] = new_value
               update_column self.class.workflow_column, new_value

--- a/lib/workflow/adapters/active_record.rb
+++ b/lib/workflow/adapters/active_record.rb
@@ -16,7 +16,10 @@ module Workflow
         # database.
         def persist_workflow_state(new_value)
           # Rails 3.1 or newer
-          update_column self.class.workflow_column, new_value
+          run_callbacks :update do
+            self[self.class.workflow_column] = new_value
+            update_column self.class.workflow_column, new_value
+          end
         end
 
         private

--- a/lib/workflow/adapters/active_record.rb
+++ b/lib/workflow/adapters/active_record.rb
@@ -16,8 +16,12 @@ module Workflow
         # database.
         def persist_workflow_state(new_value)
           # Rails 3.1 or newer
-          run_callbacks :update do
-            self[self.class.workflow_column] = new_value
+          if self.class.workflow_spec && self.class.workflow_spec.with_callbacks
+            run_callbacks :update do
+              self[self.class.workflow_column] = new_value
+              update_column self.class.workflow_column, new_value
+            end
+          else
             update_column self.class.workflow_column, new_value
           end
         end

--- a/lib/workflow/specification.rb
+++ b/lib/workflow/specification.rb
@@ -5,7 +5,7 @@ require 'workflow/errors'
 
 module Workflow
   class Specification
-    attr_accessor :states, :initial_state, :meta, :with_callbacks,
+    attr_accessor :states, :initial_state, :meta, :include_callbacks,
       :on_transition_proc, :before_transition_proc, :after_transition_proc, :on_error_proc
 
     def initialize(meta = {}, &specification)
@@ -15,7 +15,7 @@ module Workflow
     end
 
     def with_callbacks
-      @with_callbacks = true
+      @include_callbacks = true
     end
 
     def state_names

--- a/lib/workflow/specification.rb
+++ b/lib/workflow/specification.rb
@@ -5,13 +5,17 @@ require 'workflow/errors'
 
 module Workflow
   class Specification
-    attr_accessor :states, :initial_state, :meta,
+    attr_accessor :states, :initial_state, :meta, :with_callbacks,
       :on_transition_proc, :before_transition_proc, :after_transition_proc, :on_error_proc
 
     def initialize(meta = {}, &specification)
       @states = Hash.new
       @meta = meta
       instance_eval(&specification)
+    end
+
+    def with_callbacks
+      @with_callbacks = true
     end
 
     def state_names

--- a/test/main_test.rb
+++ b/test/main_test.rb
@@ -13,6 +13,8 @@ ActiveRecord::Migration.verbose = false
 class Order < ActiveRecord::Base
   include Workflow
   workflow do
+    with_callbacks
+
     state :submitted do
       event :accept, :transitions_to => :accepted, :meta => {:weight => 8} do |reviewer, args|
       end
@@ -104,6 +106,12 @@ class MainTest < ActiveRecordTestCase
     o = assert_state 'some order', 'accepted'
     assert o.ship!
     assert(o.instance_variable_get(:@capture_wf_change))
+  end
+
+  test 'after update hook is not called' do
+    o = assert_state 'some order', 'accepted', LegacyOrder
+    assert o.ship!
+    assert(!o.instance_variable_get(:@capture_wf_change))
   end
 
   test 'immediately save the new workflow_state on state machine transition' do

--- a/test/main_test.rb
+++ b/test/main_test.rb
@@ -60,6 +60,8 @@ end
 class SpecialSmallImage < SmallImage
 end
 
+Order.after_update { @capture_wf_change = workflow_state_changed? }
+
 class MainTest < ActiveRecordTestCase
 
   def setup
@@ -96,6 +98,12 @@ class MainTest < ActiveRecordTestCase
     o = klass.find_by_title(title)
     assert_equal expected_state, o.read_attribute(klass.workflow_column)
     o
+  end
+
+  test 'after update hook is called' do
+    o = assert_state 'some order', 'accepted'
+    assert o.ship!
+    assert(o.instance_variable_get(:@capture_wf_change))
   end
 
   test 'immediately save the new workflow_state on state machine transition' do

--- a/workflow.gemspec
+++ b/workflow.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'activerecord'
   gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'mocha'
+  gem.add_development_dependency 'protected_attributes'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'test-unit'
   gem.add_development_dependency 'ruby-graphviz', ['~> 1.0.0']


### PR DESCRIPTION
- Add option to call `after_update` hooks when transitioning state.
- Papertrail uses the after upate hook of a model, this ensures that the
    update hooks are called when changing state.
- uses:

```
workflow do
  with_callbacks
    # other important directives
  end
```

when `with_callbacks` is used in the workflow specification,
ActiveRecord update callbacks will be invoked when transitioning state