### PR TITLE
Optimistic locking blocks

### DIFF
--- a/lib/workflow/version.rb
+++ b/lib/workflow/version.rb
@@ -1,3 +1,3 @@
 module Workflow
-  VERSION = "1.3.0"
+  VERSION = "1.4.0"
 end

--- a/test/block_without_active_record_test.rb
+++ b/test/block_without_active_record_test.rb
@@ -1,0 +1,55 @@
+require File.join(File.dirname(__FILE__), 'test_helper')
+
+$VERBOSE = false
+require 'workflow'
+
+class BlockWithoutActiveRecord < Test::Unit::TestCase
+  class Task
+    attr_accessor :duration
+
+    include Workflow
+
+    workflow do
+      state :active do
+        event :pause, :transitions_to => :paused
+        event :complete, :transitions_to => :completed
+      end
+      state :paused do
+        event :resume, :transitions_to => :active
+      end
+      state :completed
+    end
+  end
+
+  test 'with a block that transitions successfully' do
+    task = Task.new
+
+    assert_nil task.duration
+
+    task.pause! do
+      task.duration = 1
+    end
+
+    assert task.paused?
+    assert_equal 1, task.duration
+  end
+
+  test 'with a block and an illegal transition' do
+    task = Task.new
+
+    assert_nil task.duration
+
+    task.pause! do
+      task.duration = 1
+    end
+
+    assert_raise Workflow::NoTransitionAllowed do
+      task.complete! do
+        task.duration = 2
+      end
+    end
+
+    assert task.paused?
+    assert_equal 1, task.duration
+  end
+end

--- a/test/optimistic_locking_blocks_test.rb
+++ b/test/optimistic_locking_blocks_test.rb
@@ -1,0 +1,124 @@
+require File.join(File.dirname(__FILE__), 'test_helper')
+
+$VERBOSE = false
+require 'active_record'
+require 'sqlite3'
+require 'workflow'
+
+ActiveRecord::Migration.verbose = false
+
+class Task < ActiveRecord::Base
+  include Workflow
+
+  # Use this to turn on active record validations when persisting a state change
+  # to the workflow column.
+  workflow_validate
+
+  workflow do
+    state :active do
+      event :pause, :transitions_to => :paused
+      event :complete, :transitions_to => :completed
+    end
+    state :paused do
+      event :resume, :transitions_to => :active
+    end
+    state :completed
+  end
+end
+
+class OptimisticLockingBlockTest < ActiveRecordTestCase
+
+  def setup
+    super
+
+    ActiveRecord::Schema.define do
+      create_table :tasks do |t|
+        t.integer :duration
+        t.string :workflow_state
+        t.integer :lock_version, :default => 0
+      end
+    end
+  end
+
+  test 'with a race condition' do
+    task = Task.create
+
+    task1 = Task.find(task.id)
+    task2 = Task.find(task.id)
+
+    task1.pause!
+    assert task1.paused?
+
+    assert_raise ActiveRecord::StaleObjectError do
+      task2.complete!
+    end
+
+    task.reload
+
+    assert task.paused?
+  end
+
+  test 'with a block that saves successfully' do
+    task = Task.create
+
+    assert_nil task.duration
+
+    task.pause! do
+      task.duration = 1
+    end
+
+    task.reload
+
+    assert task.paused?
+    assert_equal 1, task.duration
+  end
+
+  test 'with a block and an illegal transition' do
+    task = Task.create
+
+    assert_nil task.duration
+
+    task.pause! do
+      task.duration = 1
+    end
+
+    task.reload
+
+    assert_raise Workflow::NoTransitionAllowed do
+      task.complete! do
+        task.duration = 2
+      end
+    end
+
+    task.reload
+
+    assert task.paused?
+    assert_equal 1, task.duration
+  end
+
+  test 'with a block and a race condition' do
+    task = Task.create
+
+    task1 = Task.find(task.id)
+    task2 = Task.find(task.id)
+
+    assert_nil task.duration
+
+    task1.pause! do
+      task1.duration = 1
+    end
+
+    assert task1.paused?
+
+    assert_raise ActiveRecord::StaleObjectError do
+      task2.complete! do
+        task2.duration = 2
+      end
+    end
+
+    task.reload
+
+    assert task.paused?
+    assert_equal 1, task.duration
+  end
+end

--- a/workflow.gemspec
+++ b/workflow.gemspec
@@ -23,12 +23,13 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rdoc',    [">= 3.12"]
   gem.add_development_dependency 'bundler', [">= 1.0.0"]
-  gem.add_development_dependency 'activerecord'
+  gem.add_development_dependency 'activerecord', ["< 5.0"]
   gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'mocha'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'test-unit'
   gem.add_development_dependency 'ruby-graphviz', ['~> 1.0.0']
+  gem.add_development_dependency 'protected_attributes'
   
   gem.required_ruby_version = '>= 1.9.2'
 end


### PR DESCRIPTION
I've run into situations using this gem in which a race condition occurs.  Two state transitions are attempted at about the same time that are incompatible with each other (that is, a transition between the two ending states is not legal, but effectively occurs as a result of the race condition).  Optimistic locking is the safest way to handle such a race condition, but the existing version 1.3 of the gem circumvents validations by calling `update_column`, thus making the use of optimistic locking impossible.  This PR provides a mechanism for choosing between the default `update_column` mechanism or using a two step attribute assignment followed by `save!` to allow validations to be performed.

Also, I've seen this gem used in a manner that one transition event handler callback method isn't suitable for all situations.  If your code wants to create different side effects in different situations along with a state transition, and if you want those side effects to only occur if the state transition succeeds (it's a legal transaction _and_ the data isn't stale), the cleanest way to handle that would be to pass a block to the transition and execute that block within the same transaction as the transition.  This PR adds that capability.

I noticed that the master branch is on 1.3.0, but that version has never been published to rubygems.  I bump the version in my PR to 1.4.0 to allow for snapshotting 1.3.

Thanks!