### PR TITLE
Update graphviz installation instructions for Mac

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -522,7 +522,7 @@ Support, Participation
 ### Development Setup
 
     sudo apt-get install graphviz # Linux
-    brew cask install graphviz # Mac OS
+    brew install graphviz # Mac OS
     cd workflow
     gem install bundler
     bundle install


### PR DESCRIPTION
graphviz is no longer a cask, it was moved to homebrew core: https://formulae.brew.sh/formula/graphviz