### PR TITLE
allow event arguments to be taken into account when selecting the event

### DIFF
--- a/lib/workflow.rb
+++ b/lib/workflow.rb
@@ -95,7 +95,7 @@ module Workflow
     end
 
     def process_event!(name, *args)
-      event = current_state.events.first_applicable(name, self)
+      event = current_state.events.first_applicable(name, self, args)
       raise NoTransitionAllowed.new(
         "There is no event #{name.to_sym} defined for the #{current_state} state") \
         if event.nil?

--- a/lib/workflow/event.rb
+++ b/lib/workflow/event.rb
@@ -15,12 +15,12 @@ module Workflow
                    end
     end
 
-    def condition_applicable?(object)
+    def condition_applicable?(object, event_arguments)
       if condition
         if condition.is_a?(Symbol)
-          object.send(condition)
+          object.send(condition, *event_arguments)
         else
-          condition.call(object)
+          condition.call(object, *event_arguments)
         end
       else
         true

--- a/lib/workflow/event_collection.rb
+++ b/lib/workflow/event_collection.rb
@@ -26,9 +26,9 @@ module Workflow
       end
     end
 
-    def first_applicable(name, object_context)
+    def first_applicable(name, object_context, event_arguments)
       (self[name] || []).detect do |event|
-        event.condition_applicable?(object_context) && event
+        event.condition_applicable?(object_context, event_arguments) && event
       end
     end
 


### PR DESCRIPTION
This allows access to event arguments when we're evaluating which event to run in the scope of 

```
state :off
  event :turn_on, :transition_to => :on, :if => :sufficient_battery_level?

  event :turn_on, :transition_to => :low_battery, :if => proc { |device, _power_adapter| device.battery_level > 0 }
end

# corresponding instance method
def sufficient_battery_level?(power_adapter)
  power_adapter || battery_level > 10
end
```

@geekq I imagine this potentially is a breaking change but I run into a situation when event arguments had to be taken into account for conditional event - let me know what you think 👍 🙇 

