### PR TITLE
doc(README): add `on_error` hook reference

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -487,7 +487,7 @@ The whole event sequence is as follows:
     * event specific action
     * on_transition (if action did not halt)
     * on_exit
-    * PERSIST WORKFLOW STATE, i.e. transition
+    * PERSIST WORKFLOW STATE (i.e. transition) or on_error
     * on_entry
     * after_transition
 
@@ -561,4 +561,3 @@ Copyright (c) 2007-2008 Ryan Allen, FlashDen Pty Ltd
 Based on the work of Ryan Allen and Scott Barron
 
 Licensed under MIT license, see the MIT-LICENSE file.
-


### PR DESCRIPTION
`on_error` wasn't referenced in the hook list, so I added alongside the `transition` hook, based on [this sequence of calls](https://github.com/geekq/workflow/blob/ba6946ba6711e2d255cc2fd5d28e6af3add3df36/lib/workflow.rb#L113-L117) in the gem.