### PR TITLE
Update conditional argument handling to correctly support lambdas

### DIFF
--- a/lib/workflow/event.rb
+++ b/lib/workflow/event.rb
@@ -28,9 +28,13 @@ module Workflow
             object.send(condition, *event_arguments)
           end
         else
-          # since blocks can ignore extra arguments without raising an error in Ruby,
-          # no `if` is needed - compare with `arity` switch in above methods handling
-          condition.call(object, *event_arguments)
+          # Blocks and non-lambda Procs can ignore extra arguments without raising an error in Ruby,
+          # but lambdas cannot, so we still have to check arity
+          if condition.arity == 1 # no additional parameters accepted
+            condition.call(object)
+          else
+            condition.call(object, *event_arguments)
+          end
         end
       else
         true

--- a/test/conditionals_test.rb
+++ b/test/conditionals_test.rb
@@ -92,7 +92,8 @@ class ConditionalsTest < Minitest::Test
           event :turn_on, :transitions_to => :low_battery # otherwise
         end
         state :on do
-          event :check, :transitions_to => :low_battery, :if => proc { |obj| return false }
+          # Use a lambda proc, which enforces correct arity
+          event :check, :transitions_to => :low_battery, :if => -> (obj) { return false }
           event :check, :transitions_to => :on # stay in on state otherwise
         end
         state :low_battery


### PR DESCRIPTION
# Summary

This PR fixes the event `condition` call to check arity even when not using methods, since the user may have defined a condition using a lambda instead of a block. ie.

```ruby
state :inside do
  event :exit, transitions_to: :outside, if: ->(obj) { dont_need_args(obj) }
end
```

Without this PR's change, this example raises an ArgumentError if you do something like `obj.exit!(123)`, because the lambda is being called with 2 arguments when it expects 1.

# Explanation

There are two types of Procs in Ruby, lambda-based procs and non-lambda (block-like) procs. They enforce arguments differently:

*Block like*
```
irb(main):001* proc_block = Proc.new do |a,b|
irb(main):002*   puts "a: #{a}, b: #{b}"
irb(main):003> end
=> #<Proc:0x000000012d315208 (irb):1>
irb(main):005> proc_block.call(1)
a: 1, b:
=> nil
irb(main):006> proc_block.call(1,2)
a: 1, b: 2
=> nil
irb(main):007> proc_block.call(1,2, 3)
a: 1, b: 2
=> nil
```
*Lambda/stabby arrow*
```
irb(main):004> proc_lambda = -> (a,b) { puts "a: #{a}, b: #{b}"  }
=> #<Proc:0x000000012cd39c80 (irb):4 (lambda)>
irb(main):008> proc_lambda.call(1)
(irb):4:in 'block in <top (required)>': wrong number of arguments (given 1, expected 2) (ArgumentError)
irb(main):009> proc_lambda.call(1,2)
a: 1, b: 2
=> nil
irb(main):010> proc_lambda.call(1,2,3)
(irb):4:in 'block in <top (required)>': wrong number of arguments (given 3, expected 2) (ArgumentError)
```

Thus we should check arity when calling an event's condition method or block/proc/lambda.